### PR TITLE
Added input path error handling

### DIFF
--- a/gltfjsx.js
+++ b/gltfjsx.js
@@ -83,7 +83,9 @@ module.exports = function(file, output, { draco, animation }) {
 
   const stream = fs.createWriteStream(output || name.charAt(0).toUpperCase() + name.slice(1) + '.js')
   stream.once('open', fd => {
-    if (fs.existsSync(file)) {
+    if (!fs.existsSync(file)) {
+      console.error(`\nERROR: The input file: "${file}" does not exist at this path.\n`);
+    } else {
       const data = fs.readFileSync(file)
       const arrayBuffer = toArrayBuffer(data)
       gltfLoader.parse(


### PR DESCRIPTION
I revised the `existsSync` conditional to log an error if the file doesn't exist as the silent failure was hard to track down otherwise.

For the solve, I opted for an `if..else` to make the code changes as minimal as possible AND maintain the JSX markup spacing (also considered a `return;` out if that if condition as well as a `process.exit();`, but I figured I'd get this reviewed first).

---

[EDIT]
FWIW, this Pull Request stemmed from me running the `npx` command at the root of my project ([similar to this attempt](https://spectrum.chat/react-three-fiber/general/empty-file-from-npx-gltfjsx~7ec81daf-3771-4c9d-9662-ffc07d0b0c10?m=MTU3MzcyOTAzNDcwNw==) it seems) vs. within the same directory as my GLTF file and then getting an empty output file. I assumed the issue was with my GLTF export settings, so I took way too much time "debugging" that before digging into the code and realizing the relative path mattered and I had to run the command in the same directory as the GLTF file 🤦‍♂️.