### PR TITLE
add type to group ref

### DIFF
--- a/gltfjsx.js
+++ b/gltfjsx.js
@@ -137,10 +137,10 @@ function printClips(gltf) {
 
 function printAnimations(gltf, options) {
   let rootNode = ''
-  let actionsValue = ''
+  let useRefText = 'useRef()'
 
   if (options.types) {
-    actionsValue = `null as null | GLTFActions`
+    useRefText = 'useRef<GLTFActions>()'
     rootNode = 'null as any'
     gltf.scene.traverse((child) => {
       if (child.type === 'SkinnedMesh') {
@@ -150,7 +150,7 @@ function printAnimations(gltf, options) {
   }
 
   return gltf.animations && gltf.animations.length
-    ? `\n\n  const actions = useRef(${actionsValue})
+    ? `\n\n  const actions = ${useRefText}
   const [mixer] = useState(() => new THREE.AnimationMixer(${rootNode}))
   useFrame((state, delta) => mixer.update(delta))
   useEffect(() => {
@@ -201,7 +201,7 @@ import { GLTFLoader${options.types ? ', GLTF' : ''} } from 'three/examples/jsm/l
             }
 ${options.types ? printTypes(objects, animations) : ''}
 export default function Model(props${options.types ? ": JSX.IntrinsicElements['group']" : ''}) {
-  const group = useRef()
+  const group = ${options.types ? 'useRef<THREE.Object3D>()' : 'useRef()'}
   const { nodes, materials${options.animation ? ', animations' : ''} } = useLoader${
               options.types ? '<GLTFResult>' : ''
             }(GLTFLoader, '/${nameExt}'${options.draco ? `, draco(${JSON.stringify(options.binary)})` : ``})${


### PR DESCRIPTION
**Reason**
In typescript, previously reading from group.current would show an  error
```
  const readPosition= useCallback(() => {
    if (group && group.current !== undefined) {
      group.current.position; // Error: Object is possibly 'undefined'
    }
  }, []);
```


**Main changes**
* Adds type for the group ref
`useRef()` > `useRef<THREE.Object3D>()` 
* updates actions type to match same style, (null isn't required as the initial value for the refs)
`useRef(null as null | GLTFActions)` > `useRef<GLTFActions>()`
